### PR TITLE
Improve file uploading / downloading from url

### DIFF
--- a/src/main/java/fi/ubigu/gsdig/upload/format/GeoJSONFormat.java
+++ b/src/main/java/fi/ubigu/gsdig/upload/format/GeoJSONFormat.java
@@ -26,15 +26,21 @@ public class GeoJSONFormat implements UploadFormat {
         for (File readableFile : getReadableFiles(file)) {
             DataStore store = null;
             try {
-                store = new GeoJSONDataStore(readableFile, om, null);
-                String typeName = store.getTypeNames()[0];
-                SimpleFeatureSource source = store.getFeatureSource(typeName);
-                SimpleFeatureCollection collection = source.getFeatures();
+                String typeName;
+                SimpleFeatureCollection collection;
+                try {
+                    store = new GeoJSONDataStore(readableFile, om, null);
+                    typeName = store.getTypeNames()[0];
+                    SimpleFeatureSource source = store.getFeatureSource(typeName);
+                    collection = source.getFeatures();
+                    if (collection.isEmpty()) {
+                        continue;
+                    }
+                } catch (Exception ignore) {
+                    continue;
+                }
                 next.accept(typeName, collection);
                 return true;
-            } catch (Exception ignore) {
-                // Just ignore it
-                ignore.printStackTrace();
             } finally {
                 if (store != null) {
                     store.dispose();

--- a/src/main/java/fi/ubigu/gsdig/upload/format/ShpFormat.java
+++ b/src/main/java/fi/ubigu/gsdig/upload/format/ShpFormat.java
@@ -1,7 +1,6 @@
 package fi.ubigu.gsdig.upload.format;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
@@ -36,21 +35,25 @@ public class ShpFormat implements UploadFormat {
         DataStore store = null;
         try {
             store = DataStoreFinder.getDataStore(params);
-            String typeName =  store.getTypeNames()[0];
-            SimpleFeatureSource source = store.getFeatureSource(typeName);
-            SimpleFeatureCollection collection = source.getFeatures();
+            String typeName;
+            SimpleFeatureCollection collection;
+            try {
+                typeName =  store.getTypeNames()[0];
+                SimpleFeatureSource source = store.getFeatureSource(typeName);
+                collection = source.getFeatures();
+                if (collection.isEmpty()) {
+                    return false;
+                }
+            } catch (Exception e) {
+                return false;
+            }
             next.accept(typeName, collection);
             return true;
-        } catch (IOException e) {
-            // Just ignore it
-            e.printStackTrace();
         } finally {
             if (store != null) {
                 store.dispose();
             }
         }
-
-        return false;
     }
 
     @Override

--- a/src/main/java/fi/ubigu/gsdig/utility/FileSafety.java
+++ b/src/main/java/fi/ubigu/gsdig/utility/FileSafety.java
@@ -1,0 +1,25 @@
+package fi.ubigu.gsdig.utility;
+
+import java.io.File;
+import java.io.IOException;
+
+public class FileSafety {
+
+    /**
+     * Avoid Zip Slip / other malicious issues
+     * @see https://snyk.io/research/zip-slip-vulnerability
+     */
+    public static File newFile(File destDir, String name) throws IOException {
+        File destFile = new File(destDir, name);
+
+        String destDirPath = destDir.getCanonicalPath();
+        String destFilePath = destFile.getCanonicalPath();
+
+        if (!destFilePath.startsWith(destDirPath + File.separator)) {
+            throw new IllegalArgumentException("Entry is outside of the target dir: " + name);
+        }
+
+        return destFile;
+    }
+
+}


### PR DESCRIPTION
Allow original filename to be preserved. This has two positive effect:
-  GeoJSON/CSV feature collections now use the original file name as their default name instead of cryptic random UUID serialized in string format
- Shape files work with just bare .shp files

Additionally, in GeoJSON, CSV and Shape files don't allow empty collections to be written as succesful upload. Also separate the part of reading/opening the file from storing the contents inside the database,  e.g. don't swallow exceptions originating from writing the contents to the database.